### PR TITLE
bytecode: fix const serialisation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ project_options(
 
 # TODO: Address all the warning below. This should be only temporary...
 target_compile_options(project_warnings
-  INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-Wno-sign-conversion;-Wno-shadow;-Wno-implicit-fallthrough;-Wno-old-style-cast;-Wno-deprecated-copy;-Wno-missing-field-initializers;-Wno-null-dereference;-Wno-maybe-uninitialized>
+  INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-Wno-sign-conversion;-Wno-shadow;-Wno-implicit-fallthrough;-Wno-old-style-cast;-Wno-deprecated-copy;-Wno-missing-field-initializers;-Wno-null-dereference;-Wno-maybe-uninitialized;-Wno-stringop-overflow>
 )
 
 check_cxx_source_compiles(

--- a/src/executable/bytecode/serialization/deserialize.hpp
+++ b/src/executable/bytecode/serialization/deserialize.hpp
@@ -3,6 +3,7 @@
 #include "forward.hpp"
 #include "runtime/Value.hpp"
 #include "serialize.hpp"
+#include "utilities.hpp"
 
 #include <span>
 #include <string>


### PR DESCRIPTION
Nested tuples were not being serialised properly, they were just serialised as bytes, which does not work with nested tuples and strings.