### PR TITLE
ci: require synchronous agents in the code-review command

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -5,6 +5,8 @@ description: Code review a pull request, posting inline comments on the relevant
 
 Provide a code review for the given pull request.
 
+IMPORTANT: This command runs in a headless CI job. Launch every agent synchronously (in the foreground, `run_in_background: false`) and wait for its result before moving to the next step. Never end your turn while agents are still running: if the turn ends with agents pending, the job terminates immediately and the review is silently lost.
+
 To do this, follow these steps precisely:
 
 1. Launch a haiku agent to check if any of the following are true:


### PR DESCRIPTION
Since Claude Code 2.1.2xx (pulled in by the floating claude-code-action@v1 tag), the Agent tool launches subagents in the background by default. When the orchestrating agent ends its turn while reviewers are still running, the headless CI session terminates and the review is silently dropped.

Instruct the command to run every agent in the foreground and never end the turn with agents pending.